### PR TITLE
Rename $plugin to prevent variable name conflict

### DIFF
--- a/basic-scaffold.php
+++ b/basic-scaffold.php
@@ -101,22 +101,22 @@ if ( ! class_exists( __NAMESPACE__ . '\\PluginFactory' ) ) {
  * For more information on why to avoid a Singleton,
  * @see https://www.alainschlesser.com/singletons-shared-instances/
  */
-$plugin = BasicScaffoldPluginFactory::create();
+$pluginObject = BasicScaffoldPluginFactory::create();
 
 /*
  * We register activation and deactivation hooks by using closures, as these
  * need static access to work correctly.
  */
-\register_activation_hook( __FILE__, function () use ( $plugin ) {
-	$plugin->activate();
+\register_activation_hook( __FILE__, function () use ( $pluginObject ) {
+	$pluginObject->activate();
 } );
 
-\register_deactivation_hook( __FILE__, function () use ( $plugin ) {
-	$plugin->deactivate();
+\register_deactivation_hook( __FILE__, function () use ( $pluginObject ) {
+	$pluginObject->deactivate();
 } );
 
 /*
  * Finally, we run the plugin's register method to Hook the plugin into the
  * WordPress request lifecycle.
  */
-$plugin->register();
+$pluginObject->register();


### PR DESCRIPTION
At [the place the plugin file is included](https://github.com/WordPress/WordPress/blob/22d8c0af3c491b3e0d10bb27c4af1997c255a659/wp-settings.php#L361-L371) there already is a variable `$plugin` containing the path to the plugin file which is overwritten with the Plugin object.

At first look this doesn't cause much issues, but e.g. [a plugin expecting the return value of `plugin_loaded` to be a `string`](https://github.com/Rarst/laps/blob/e6bb7fadaa72739b9df5b23fbfbe203df7772398/src/Record/Collector/Plugin_Load_Collector.php#L35) would Fatal here.